### PR TITLE
Hide/show default selected date header and add callback when the selected date range updates.

### DIFF
--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -134,8 +134,8 @@ class ViewController: UIViewController {
                 print("any actions")
             }
         }
-        fastisController.dateSelectionHandler = { date in
-            print("date \(date)")
+        fastisController.dateRangeSelectionHandler = { range in
+            print("date range:", range)
         }
         fastisController.present(above: self)
     }
@@ -156,6 +156,9 @@ class ViewController: UIViewController {
                 print("any actions")
             }
         }
+        fastisController.dateSelectionHandler = { date in
+            print("date: ", date)
+        }
         fastisController.present(above: self)
     }
 
@@ -175,8 +178,8 @@ class ViewController: UIViewController {
         fastisController.maximumDate = calendar.date(byAdding: .month, value: 3, to: Date())
         fastisController.allowToChooseNilDate = true
         fastisController.shortcuts = [.today, .lastWeek, .lastMonth]
-        fastisController.dateSelectionHandler = { date in
-            print("date \(date)")
+        fastisController.dateRangeSelectionHandler = { range in
+            print("date range: ", range)
         }
         fastisController.present(above: self)
     }

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -124,8 +124,8 @@ class ViewController: UIViewController {
         fastisController.initialValue = self.currentValue as? FastisRange
         fastisController.minimumDate = Calendar.current.date(byAdding: .month, value: -2, to: Date())
         fastisController.maximumDate = Calendar.current.date(byAdding: .month, value: 3, to: Date())
-        fastisController.allowToChooseNilDate = true
         fastisController.shortcuts = [.today, .lastWeek, .lastMonth]
+        fastisController.shouldShowDateSelectionHeader = false
         fastisController.dismissHandler = { [weak self] action in
             switch action {
             case .done(let newValue):
@@ -133,6 +133,9 @@ class ViewController: UIViewController {
             case .cancel:
                 print("any actions")
             }
+        }
+        fastisController.dateSelectionHandler = { date in
+            print("date \(date)")
         }
         fastisController.present(above: self)
     }
@@ -172,13 +175,8 @@ class ViewController: UIViewController {
         fastisController.maximumDate = calendar.date(byAdding: .month, value: 3, to: Date())
         fastisController.allowToChooseNilDate = true
         fastisController.shortcuts = [.today, .lastWeek, .lastMonth]
-        fastisController.dismissHandler = { [weak self] action in
-            switch action {
-            case .done(let newValue):
-                self?.currentValue = newValue
-            case .cancel:
-                print("any actions")
-            }
+        fastisController.dateSelectionHandler = { date in
+            print("date \(date)")
         }
         fastisController.present(above: self)
     }


### PR DESCRIPTION
- Customize the visiblity of the default selected date header.
- Add the closures to handle on date selection callbacks.